### PR TITLE
Use in-game names to make the console more user-friendly

### DIFF
--- a/Stoker.Base/Builder/CommandBuilder.cs
+++ b/Stoker.Base/Builder/CommandBuilder.cs
@@ -53,6 +53,17 @@ namespace Stoker.Base.Builder
             return new ArgumentBuilder<T>(this, argument);
         }
 
+        public ArgumentBuilder<string> WithSimpleNameArg()
+        {
+            var argument = new Argument<string>
+            {
+                Name = "name"
+            };
+            _command.AddArgument(argument);
+            _command.simpleNameArg = true;
+            return new ArgumentBuilder<string>(this, argument);
+        }
+
         /// <summary>
         /// Adds an option to the command.
         /// </summary>

--- a/Stoker.Base/Commands/CardCommandFactory.cs
+++ b/Stoker.Base/Commands/CardCommandFactory.cs
@@ -162,15 +162,30 @@ namespace Stoker.Base.Commands
                             throw new Exception("Invalid --page option");
                         if (options["page-size"] is not int pageSize)
                             throw new Exception("Invalid --page-size option");
-                        var cards = Railend.GetContainer().GetInstance<IRegister<CardData>>();
-                        var startIndex = (page - 1) * pageSize;
-                        var endIndex = startIndex + pageSize;
-                        var pageCards = cards.Skip(startIndex).Take(pageSize);
-                        LoggerLazy.Value.Log("Cards:");
-                        foreach (var card in pageCards)
+
+
+                        Type type = typeof(CheatManager);
+                        FieldInfo field = type.GetField("allGameData", BindingFlags.NonPublic | BindingFlags.Static);
+
+                        if (field != null)
                         {
-                            LoggerLazy.Value.Log($"{card.Value.Cheat_GetNameEnglish()} : {card.Value.name}");
+                            AllGameData? allGameData = field.GetValue(null) as AllGameData;
+                            if (allGameData != null)
+                            {
+                                List<CardData> cards = allGameData.GetAllCardData().ToList();
+                                cards.FindAll(c => c.IsUnitAbility()).ForEach(c => cards.Remove(c)); // Remove unit abilities
+                                cards.Sort((x, y) => string.Compare(x.Cheat_GetNameEnglish(), y.Cheat_GetNameEnglish(), StringComparison.OrdinalIgnoreCase));
+                                var startIndex = (page - 1) * pageSize;
+                                var endIndex = startIndex + pageSize;
+                                var pageCards = cards.Skip(startIndex).Take(pageSize);
+                                LoggerLazy.Value.Log("Cards:");
+                                foreach (var card in pageCards)
+                                {
+                                    LoggerLazy.Value.Log($"{card.Cheat_GetNameEnglish()}");
+                                }
+                            }
                         }
+
                         return Task.CompletedTask;
                     })
                     .UseHelpMiddleware()

--- a/Stoker.Base/Commands/EventCommandFactory.cs
+++ b/Stoker.Base/Commands/EventCommandFactory.cs
@@ -1,14 +1,9 @@
 ﻿using HarmonyLib;
-using ShinyShoe.Loading;
 using Stoker.Base.Builder;
 using Stoker.Base.Extension;
-using Stoker.Base.Impl;
 using Stoker.Base.Interfaces;
 using System.Reflection;
-using TrainworksReloaded.Base;
 using TrainworksReloaded.Core;
-using TrainworksReloaded.Core.Enum;
-using TrainworksReloaded.Core.Interfaces;
 
 namespace Stoker.Base.Commands
 {
@@ -31,10 +26,10 @@ namespace Stoker.Base.Commands
 
                             if (field != null)
                             {
-                                AllGameData allGameData = field.GetValue(null) as AllGameData;
+                                AllGameData? allGameData = field.GetValue(null) as AllGameData;
                                 if (allGameData != null)
                                 {
-                                    return allGameData.GetAllStoryEventData().Select(s => s.name).ToArray();
+                                    return [.. allGameData.GetAllStoryEventData().Select(s => s.name)];
                                 }
                             }
                             return [];
@@ -65,10 +60,10 @@ namespace Stoker.Base.Commands
 
                         if (field != null)
                         {
-                            AllGameData allGameData = field.GetValue(null) as AllGameData;
+                            AllGameData? allGameData = field.GetValue(null) as AllGameData;
                             if (allGameData != null)
                             {
-                                List<String> names = allGameData.GetAllStoryEventData().Select(s => s.name).ToList();
+                                List<String> names = [.. allGameData.GetAllStoryEventData().Select(s => s.name)];
                                 names.Sort();
                                 names.ForEach(s => LoggerLazy.Value.Log(s));
                             }

--- a/Stoker.Base/Commands/EventCommandFactory.cs
+++ b/Stoker.Base/Commands/EventCommandFactory.cs
@@ -1,0 +1,85 @@
+﻿using HarmonyLib;
+using ShinyShoe.Loading;
+using Stoker.Base.Builder;
+using Stoker.Base.Extension;
+using Stoker.Base.Impl;
+using Stoker.Base.Interfaces;
+using System.Reflection;
+using TrainworksReloaded.Base;
+using TrainworksReloaded.Core;
+using TrainworksReloaded.Core.Enum;
+using TrainworksReloaded.Core.Interfaces;
+
+namespace Stoker.Base.Commands
+{
+    public class EventCommandFactory
+    {
+        private static Lazy<ConsoleLogger> LoggerLazy { get; set; } = new(() => Railend.GetContainer().GetInstance<ConsoleLogger>());
+
+        public static ICommand Create()
+        {
+            var command = new CommandBuilder("event")
+                .WithDescription("Manage events")
+                .WithSubCommand("trigger")
+                .WithDescription("Trigger an event")
+                    .WithSimpleNameArg()
+                        .WithDescription("The name of the event to trigger")
+                        .WithSuggestions(() =>
+                        {
+                            Type type = typeof(CheatManager);
+                            FieldInfo field = type.GetField("allGameData", BindingFlags.NonPublic | BindingFlags.Static);
+
+                            if (field != null)
+                            {
+                                AllGameData allGameData = field.GetValue(null) as AllGameData;
+                                if (allGameData != null)
+                                {
+                                    return allGameData.GetAllStoryEventData().Select(s => s.name).ToArray();
+                                }
+                            }
+                            return [];
+                        })
+                        .WithParser((xs) => xs)
+                        .Parent()
+                    .SetHandler((args) =>
+                    {
+                        var arguments = args.Arguments;
+                        if (!arguments.ContainsKey("name"))
+                            throw new Exception("Missing <name> argument");
+                        if (arguments["name"] is not string eventName)
+                            throw new Exception("Invalid <name> argument");
+                        if (string.IsNullOrEmpty(eventName))
+                            throw new Exception("Empty <name> argument");
+                        LoggerLazy.Value.Log($"Trigerring event: {eventName}");
+                        AccessTools.Method(typeof(CheatManager), "Command_StartEvent").Invoke(null, [eventName]);
+                        return Task.CompletedTask;
+                    })
+                    .UseHelpMiddleware()
+                    .Parent()
+                .WithSubCommand("list")
+                    .WithDescription("List all events")
+                    .SetHandler((args) =>
+                    {
+                        Type type = typeof(CheatManager);
+                        FieldInfo field = type.GetField("allGameData", BindingFlags.NonPublic | BindingFlags.Static);
+
+                        if (field != null)
+                        {
+                            AllGameData allGameData = field.GetValue(null) as AllGameData;
+                            if (allGameData != null)
+                            {
+                                List<String> names = allGameData.GetAllStoryEventData().Select(s => s.name).ToList();
+                                names.Sort();
+                                names.ForEach(s => LoggerLazy.Value.Log(s));
+                            }
+                        }
+                        return Task.CompletedTask;
+                    })
+                    .UseHelpMiddleware()
+                    .Parent()
+                .UseHelpMiddleware()
+                .Build();
+            return command;
+        }
+    }
+}

--- a/Stoker.Base/Commands/NodeCommandFactory.cs
+++ b/Stoker.Base/Commands/NodeCommandFactory.cs
@@ -1,0 +1,86 @@
+﻿using HarmonyLib;
+using Stoker.Base.Builder;
+using Stoker.Base.Extension;
+using Stoker.Base.Interfaces;
+using System;
+using System.Collections.Generic;
+using System.Reflection;
+using System.Text;
+using TrainworksReloaded.Core;
+
+namespace Stoker.Base.Commands
+{
+    public class NodeCommandFactory
+    {
+        private static Lazy<ConsoleLogger> LoggerLazy { get; set; } = new(() => Railend.GetContainer().GetInstance<ConsoleLogger>());
+
+        public static ICommand Create()
+        {
+            var command = new CommandBuilder("node")
+                .WithDescription("Manage nodes")
+                .WithSubCommand("next")
+                .WithDescription("Move to the next node")
+                    .SetHandler((args) =>
+                    {
+                        LoggerLazy.Value.Log($"Moving to next node");
+                        AccessTools.Method(typeof(CheatManager), "Command_NextNode").Invoke(null, []);
+                        return Task.CompletedTask;
+                    })
+                    .UseHelpMiddleware()
+                    .Parent()
+                .WithSubCommand("prev")
+                    .WithDescription("Move to the previous node")
+                    .SetHandler((args) =>
+                    {
+                        LoggerLazy.Value.Log($"Moving to previous node");
+                        AccessTools.Method(typeof(CheatManager), "Command_PreviousNode").Invoke(null, []);
+                        return Task.CompletedTask;
+                    })
+                    .UseHelpMiddleware()
+                    .Parent()
+                .WithSubCommand("final")
+                    .WithDescription("Move to the final node")
+                    .SetHandler((args) =>
+                    {
+                        LoggerLazy.Value.Log($"Moving to final node");
+                        AccessTools.Method(typeof(CheatManager), "Command_FinalNode").Invoke(null, []);
+                        return Task.CompletedTask;
+                    })
+                    .UseHelpMiddleware()
+                    .Parent()
+                .WithSubCommand("tfb")
+                    .WithDescription("Move to tfb")
+                    .SetHandler((args) =>
+                    {
+                        LoggerLazy.Value.Log($"Moving to tfb");
+                        AccessTools.Method(typeof(CheatManager), "Command_JumpToTFB").Invoke(null, []);
+                        return Task.CompletedTask;
+                    })
+                    .UseHelpMiddleware()
+                    .Parent()
+               .WithSubCommand("reset")
+                    .WithDescription("Reset node")
+                    .SetHandler((args) =>
+                    {
+                        LoggerLazy.Value.Log($"Resetting node");
+                        AccessTools.Method(typeof(CheatManager), "Command_ResetNode").Invoke(null, []);
+                        return Task.CompletedTask;
+                    })
+                    .UseHelpMiddleware()
+                    .Parent()
+                .WithSubCommand("side")
+                    .WithDescription("Change to the other side of the node")
+                    .SetHandler((args) =>
+                    {
+                        LoggerLazy.Value.Log($"Changing to the other side of the node");
+                        AccessTools.Method(typeof(CheatManager), "Command_ChangeSides").Invoke(null, []);
+                        return Task.CompletedTask;
+                    })
+                    .UseHelpMiddleware()
+                    .Parent()
+                .UseHelpMiddleware()
+                .Build();
+            return command;
+        }
+    }
+}

--- a/Stoker.Base/Commands/RelicCommandFactory.cs
+++ b/Stoker.Base/Commands/RelicCommandFactory.cs
@@ -113,14 +113,26 @@ public class RelicCommandFactory
                         throw new Exception("Invalid --page option");
                     if (options["page-size"] is not int pageSize)
                         throw new Exception("Invalid --page-size option");
-                    var relics = Railend.GetContainer().GetInstance<IRegister<RelicData>>();
-                    var startIndex = (page - 1) * pageSize;
-                    var endIndex = startIndex + pageSize;
-                    var pageRelics = relics.Skip(startIndex).Take(pageSize);
-                    LoggerLazy.Value.Log("Relics:");
-                    foreach (var relic in pageRelics)
+
+                    Type type = typeof(CheatManager);
+                    FieldInfo field = type.GetField("allGameData", BindingFlags.NonPublic | BindingFlags.Static);
+
+                    if (field != null)
                     {
-                        LoggerLazy.Value.Log($"{relic.Value.Cheat_GetNameEnglish()} : {relic.Value.name}");
+                        AllGameData? allGameData = field.GetValue(null) as AllGameData;
+                        if (allGameData != null)
+                        {
+                            List<CollectableRelicData> relics = allGameData.GetAllCollectableRelicData().ToList();
+                            relics.Sort((a, b) => string.Compare(a.Cheat_GetNameEnglish(), b.Cheat_GetNameEnglish(), StringComparison.OrdinalIgnoreCase));
+                            var startIndex = (page - 1) * pageSize;
+                            var endIndex = startIndex + pageSize;
+                            var pageRelics = relics.Skip(startIndex).Take(pageSize);
+                            LoggerLazy.Value.Log("Relics:");
+                            foreach (var relic in pageRelics)
+                            {
+                                LoggerLazy.Value.Log($"{relic.Cheat_GetNameEnglish()}");
+                            }
+                        }
                     }
                     return Task.CompletedTask;
                 })

--- a/Stoker.Base/Commands/UpgradeCommandFactory.cs
+++ b/Stoker.Base/Commands/UpgradeCommandFactory.cs
@@ -15,7 +15,7 @@ namespace Stoker.Base.Commands
         {
             var command = new CommandBuilder("upgrade")
                 .WithDescription("Manage ugprades")
-                .WithSubCommand("card")
+                .WithSubCommand("add")
                 .WithDescription("Apply an upgrade to a card")
                     .WithSimpleNameArg()
                         .WithDescription("The name of the upgrade to apply")
@@ -63,7 +63,7 @@ namespace Stoker.Base.Commands
                             AllGameData? allGameData = field.GetValue(null) as AllGameData;
                             if (allGameData != null)
                             {
-                                List<String> names = [.. allGameData.GetAllEnhancerData().Select(s => s.Cheat_GetNameEnglish() + " : " + s.name)];
+                                List<String> names = [.. allGameData.GetAllEnhancerData().Select(s => s.Cheat_GetNameEnglish())];
                                 names.Sort();
                                 names.ForEach(s => LoggerLazy.Value.Log(s));
                             }

--- a/Stoker.Base/Commands/UpgradeCommandFactory.cs
+++ b/Stoker.Base/Commands/UpgradeCommandFactory.cs
@@ -1,14 +1,9 @@
 ﻿using HarmonyLib;
-using ShinyShoe.Loading;
 using Stoker.Base.Builder;
 using Stoker.Base.Extension;
-using Stoker.Base.Impl;
 using Stoker.Base.Interfaces;
 using System.Reflection;
-using TrainworksReloaded.Base;
 using TrainworksReloaded.Core;
-using TrainworksReloaded.Core.Enum;
-using TrainworksReloaded.Core.Interfaces;
 
 namespace Stoker.Base.Commands
 {
@@ -31,10 +26,10 @@ namespace Stoker.Base.Commands
 
                             if (field != null)
                             {
-                                AllGameData allGameData = field.GetValue(null) as AllGameData;
+                                AllGameData? allGameData = field.GetValue(null) as AllGameData;
                                 if (allGameData != null)
                                 {
-                                    return allGameData.GetAllEnhancerData().Select(e => e.Cheat_GetNameEnglish()).ToArray();
+                                    return [.. allGameData.GetAllEnhancerData().Select(e => e.Cheat_GetNameEnglish())];
                                 }
                             }
                             return [];
@@ -65,10 +60,10 @@ namespace Stoker.Base.Commands
 
                         if (field != null)
                         {
-                            AllGameData allGameData = field.GetValue(null) as AllGameData;
+                            AllGameData? allGameData = field.GetValue(null) as AllGameData;
                             if (allGameData != null)
                             {
-                                List<String> names = allGameData.GetAllEnhancerData().Select(s => s.Cheat_GetNameEnglish() + " : " + s.name).ToList();
+                                List<String> names = [.. allGameData.GetAllEnhancerData().Select(s => s.Cheat_GetNameEnglish() + " : " + s.name)];
                                 names.Sort();
                                 names.ForEach(s => LoggerLazy.Value.Log(s));
                             }

--- a/Stoker.Base/Commands/UpgradeCommandFactory.cs
+++ b/Stoker.Base/Commands/UpgradeCommandFactory.cs
@@ -1,0 +1,85 @@
+﻿using HarmonyLib;
+using ShinyShoe.Loading;
+using Stoker.Base.Builder;
+using Stoker.Base.Extension;
+using Stoker.Base.Impl;
+using Stoker.Base.Interfaces;
+using System.Reflection;
+using TrainworksReloaded.Base;
+using TrainworksReloaded.Core;
+using TrainworksReloaded.Core.Enum;
+using TrainworksReloaded.Core.Interfaces;
+
+namespace Stoker.Base.Commands
+{
+    public class UpgradeCommandFactory
+    {
+        private static Lazy<ConsoleLogger> LoggerLazy { get; set; } = new(() => Railend.GetContainer().GetInstance<ConsoleLogger>());
+
+        public static ICommand Create()
+        {
+            var command = new CommandBuilder("upgrade")
+                .WithDescription("Manage ugprades")
+                .WithSubCommand("card")
+                .WithDescription("Apply an upgrade to a card")
+                    .WithSimpleNameArg()
+                        .WithDescription("The name of the upgrade to apply")
+                        .WithSuggestions(() =>
+                        {
+                            Type type = typeof(CheatManager);
+                            FieldInfo field = type.GetField("allGameData", BindingFlags.NonPublic | BindingFlags.Static);
+
+                            if (field != null)
+                            {
+                                AllGameData allGameData = field.GetValue(null) as AllGameData;
+                                if (allGameData != null)
+                                {
+                                    return allGameData.GetAllEnhancerData().Select(e => e.Cheat_GetNameEnglish()).ToArray();
+                                }
+                            }
+                            return [];
+                        })
+                        .WithParser((xs) => xs)
+                        .Parent()
+                    .SetHandler((args) =>
+                    {
+                        var arguments = args.Arguments;
+                        if (!arguments.ContainsKey("name"))
+                            throw new Exception("Missing <name> argument");
+                        if (arguments["name"] is not string upgradeName)
+                            throw new Exception("Invalid <name> argument");
+                        if (string.IsNullOrEmpty(upgradeName))
+                            throw new Exception("Empty <name> argument");
+                        LoggerLazy.Value.Log($"Applying upgrade: {upgradeName}");
+                        AccessTools.Method(typeof(CheatManager), "Command_UpgradeCard").Invoke(null, [upgradeName]);
+                        return Task.CompletedTask;
+                    })
+                    .UseHelpMiddleware()
+                    .Parent()
+                .WithSubCommand("list")
+                    .WithDescription("List all upgrades")
+                    .SetHandler((args) =>
+                    {
+                        Type type = typeof(CheatManager);
+                        FieldInfo field = type.GetField("allGameData", BindingFlags.NonPublic | BindingFlags.Static);
+
+                        if (field != null)
+                        {
+                            AllGameData allGameData = field.GetValue(null) as AllGameData;
+                            if (allGameData != null)
+                            {
+                                List<String> names = allGameData.GetAllEnhancerData().Select(s => s.Cheat_GetNameEnglish() + " : " + s.name).ToList();
+                                names.Sort();
+                                names.ForEach(s => LoggerLazy.Value.Log(s));
+                            }
+                        }
+                        return Task.CompletedTask;
+                    })
+                    .UseHelpMiddleware()
+                    .Parent()
+                .UseHelpMiddleware()
+                .Build();
+            return command;
+        }
+    }
+}

--- a/Stoker.Base/Impl/Command.cs
+++ b/Stoker.Base/Impl/Command.cs
@@ -11,6 +11,7 @@ namespace Stoker.Base.Impl
         public List<ICommandOption> Options { get; set; } = [];
         public List<ICommand> SubCommands { get; set; } = [];
         public Func<HandlerArgs, Task>? Handler { get; set; } = null;
+        public bool simpleNameArg { get; set; } = false;
 
         IEnumerable<IArgument> ICommand.Arguments => Arguments;
 
@@ -38,6 +39,13 @@ namespace Stoker.Base.Impl
             var handlerArgs = new HandlerArgs();
             var argumentIndex = 0;
             var processedOptions = new HashSet<string>();
+
+            //No need to parse just accept the string with spaces for easy logical name input
+            if(simpleNameArg)
+            {
+                handlerArgs.Arguments.Add("name", string.Join(" ", args));
+                return handlerArgs;
+            }
 
             //Add default values for all options with a default value
             foreach (var option in Options)

--- a/Stoker.Base/Stoker.Base.csproj
+++ b/Stoker.Base/Stoker.Base.csproj
@@ -13,7 +13,7 @@
     <PackageReference Include="TrainworksReloaded.Base" Version="0.4.6" />
   </ItemGroup>
 
-  <Target Name="PostBuild" AfterTargets="PostBuildEvent">
+  <!--<Target Name="PostBuild" AfterTargets="PostBuildEvent">
     <Exec Command="xcopy &quot;$(ProjectDir)\bin\Debug\netstandard2.1\*.*&quot; &quot;C:\Program Files (x86)\Steam\steamapps\common\Monster Train 2\BepInEx\plugins\MT2-Stoker&quot; /Y /I /E" />
-  </Target>
+  </Target>-->
 </Project>

--- a/Stoker.Base/Stoker.Base.csproj
+++ b/Stoker.Base/Stoker.Base.csproj
@@ -10,6 +10,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="TrainworksReloaded.Base" Version="0.2.9" />
+    <PackageReference Include="TrainworksReloaded.Base" Version="0.4.6" />
   </ItemGroup>
+
+  <Target Name="PostBuild" AfterTargets="PostBuildEvent">
+    <Exec Command="xcopy &quot;$(ProjectDir)\bin\Debug\netstandard2.1\*.*&quot; &quot;C:\Program Files (x86)\Steam\steamapps\common\Monster Train 2\BepInEx\plugins\MT2-Stoker&quot; /Y /I /E" />
+  </Target>
 </Project>

--- a/Stoker.Plugin/Plugin.cs
+++ b/Stoker.Plugin/Plugin.cs
@@ -44,6 +44,9 @@ namespace Stoker.Plugin
             rootCommandExecutor.TryAddCommand(RelicCommandFactory.Create());
             rootCommandExecutor.TryAddCommand(HandCommandFactory.Create());
             rootCommandExecutor.TryAddCommand(PyreCommandFactory.Create());
+            rootCommandExecutor.TryAddCommand(EventCommandFactory.Create());
+            rootCommandExecutor.TryAddCommand(UpgradeCommandFactory.Create());
+            rootCommandExecutor.TryAddCommand(NodeCommandFactory.Create()); // Need to reload save to see changes
 
             Railend.ConfigurePreAction(c =>
             {

--- a/Stoker.Plugin/Stoker.Plugin.csproj
+++ b/Stoker.Plugin/Stoker.Plugin.csproj
@@ -21,7 +21,7 @@
     <ProjectReference Include="..\Stoker.Base\Stoker.Base.csproj" />
   </ItemGroup>
 
-  <Target Name="PostBuild" AfterTargets="PostBuildEvent">
+  <!--<Target Name="PostBuild" AfterTargets="PostBuildEvent">
     <Exec Command="xcopy &quot;$(ProjectDir)\bin\Debug\netstandard2.1\*.*&quot; &quot;C:\Program Files (x86)\Steam\steamapps\common\Monster Train 2\BepInEx\plugins\MT2-Stoker&quot; /Y /I /E" />
-  </Target>
+  </Target>-->
 </Project>

--- a/Stoker.Plugin/Stoker.Plugin.csproj
+++ b/Stoker.Plugin/Stoker.Plugin.csproj
@@ -20,4 +20,8 @@
   <ItemGroup>
     <ProjectReference Include="..\Stoker.Base\Stoker.Base.csproj" />
   </ItemGroup>
+
+  <Target Name="PostBuild" AfterTargets="PostBuildEvent">
+    <Exec Command="xcopy &quot;$(ProjectDir)\bin\Debug\netstandard2.1\*.*&quot; &quot;C:\Program Files (x86)\Steam\steamapps\common\Monster Train 2\BepInEx\plugins\MT2-Stoker&quot; /Y /I /E" />
+  </Target>
 </Project>


### PR DESCRIPTION
- Updated Trainworks to 0.4.6
- Added a "simple name arg" flag to make a command accept a single "name" argument that includes spaces for easy card/relic name input
- Changed suggestions for adding cards/relics to use the in-game name and list all the cards/relics instead of only those added by Trainworks
- Changed card/relic listing to show entries in alphabetical order and to use the in-game name and list all the cards/relics instead of only those added by Trainworks
- Added commands to add/list upgrades
- Added commands to trigger/list story events
- Added commands related to the current map node